### PR TITLE
Set provided class options to generated class

### DIFF
--- a/packages/grpc-js/package.json
+++ b/packages/grpc-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@grpc/grpc-js",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "gRPC Library for Node - pure JS implementation",
   "homepage": "https://grpc.io/",
   "repository": "https://github.com/grpc/grpc-node/tree/master/packages/grpc-js",

--- a/packages/grpc-js/src/make-client.ts
+++ b/packages/grpc-js/src/make-client.ts
@@ -93,6 +93,8 @@ export interface ServiceClientConstructor {
   service: ServiceDefinition;
 }
 
+type ClientClassOptions = Record<string, unknown>;
+
 /**
  * Returns true, if given key is included in the blacklisted
  * keys.
@@ -119,14 +121,13 @@ function isPrototypePolluted(key: string): boolean {
 export function makeClientConstructor(
   methods: ServiceDefinition,
   serviceName: string,
-  classOptions?: {}
+  classOptions: ClientClassOptions = {}
 ): ServiceClientConstructor {
-  if (!classOptions) {
-    classOptions = {};
-  }
+  classOptions.serviceName = serviceName;
 
   class ServiceClientImpl extends Client implements ServiceClient {
     static service: ServiceDefinition;
+    static options: ClientClassOptions
     [methodName: string]: Function;
   }
 
@@ -171,6 +172,7 @@ export function makeClientConstructor(
   });
 
   ServiceClientImpl.service = methods;
+  ServiceClientImpl.options = classOptions;
 
   return ServiceClientImpl;
 }

--- a/packages/grpc-js/src/resolving-load-balancer.ts
+++ b/packages/grpc-js/src/resolving-load-balancer.ts
@@ -26,7 +26,7 @@ import { ConnectivityState } from './connectivity-state';
 import { ConfigSelector, createResolver, Resolver } from './resolver';
 import { ServiceError } from './call';
 import { Picker, UnavailablePicker, QueuePicker } from './picker';
-import { BackoffTimeout } from './backoff-timeout';
+import { BackoffOptions, BackoffTimeout } from './backoff-timeout';
 import { Status } from './constants';
 import { StatusObject } from './call-stream';
 import { Metadata } from './metadata';
@@ -248,7 +248,10 @@ export class ResolvingLoadBalancer implements LoadBalancer {
       },
       channelOptions
     );
-
+    const backoffOptions: BackoffOptions = {
+      initialDelay: channelOptions['grpc.initial_reconnect_backoff_ms'],
+      maxDelay: channelOptions['grpc.max_reconnect_backoff_ms'],
+    };
     this.backoffTimeout = new BackoffTimeout(() => {
       if (this.continueResolving) {
         this.updateResolution();
@@ -256,7 +259,7 @@ export class ResolvingLoadBalancer implements LoadBalancer {
       } else {
         this.updateState(this.latestChildState, this.latestChildPicker);
       }
-    });
+    }, backoffOptions);
     this.backoffTimeout.unref();
   }
 


### PR DESCRIPTION
Currently neither `serviceName` nor `classOptions` are not used in `makeClientConstructor` at all. In some cases it is very handy to access at least `serviceName` in generated class to identify which service exactly generated class belongs to.